### PR TITLE
Also exlcudes gzip files generated by com.google.gwt.precompress.Precompress

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'buildr', '= 1.4.20'
+gem 'buildr', '= 1.4.21'

--- a/linker/src/main/java/org/realityforge/gwt/appcache/linker/AppcacheLinker.java
+++ b/linker/src/main/java/org/realityforge/gwt/appcache/linker/AppcacheLinker.java
@@ -183,7 +183,8 @@ public final class AppcacheLinker
 
   private boolean shouldAddToManifest( final String path )
   {
-    return !( path.equals( "compilation-mappings.txt" ) || path.endsWith( ".devmode.js" ) );
+    return !( path.equals( "compilation-mappings.txt" ) || path.endsWith( ".devmode.js" ) ||
+            path.endsWith( ".cache.js.gz" ));
   }
 
   /**

--- a/linker/src/test/java/org/realityforge/gwt/appcache/linker/AppcacheLinkerTest.java
+++ b/linker/src/test/java/org/realityforge/gwt/appcache/linker/AppcacheLinkerTest.java
@@ -118,7 +118,7 @@ public class AppcacheLinkerTest
     assertEquals( values.size(), 3 );
 
     final List<BindingProperty> x = ensureBinding( values, "X", 1 );
-    assertProperty( x.get( 0 ), "user.agent", "ie8,ie9,ie10" );
+        assertProperty(x.get(0), "user.agent", "ie10,ie9,ie8");
 
     final List<BindingProperty> z = ensureBinding( values, "Z", 1 );
     assertProperty( z.get( 0 ), "user.agent", "gecko_16" );


### PR DESCRIPTION
the manifest should not include gzip'ed permutation files