### PR TITLE
Allow getBaseUrl() and getModuleName() to be overridden

### DIFF
--- a/server/src/main/java/org/realityforge/gwt/appcache/server/AbstractManifestServlet.java
+++ b/server/src/main/java/org/realityforge/gwt/appcache/server/AbstractManifestServlet.java
@@ -247,7 +247,7 @@ public abstract class AbstractManifestServlet
     return manifest;
   }
 
-  final String getBaseUrl( final HttpServletRequest request )
+  protected String getBaseUrl( final HttpServletRequest request )
   {
     final String base = request.getServletPath();
     // cut off module
@@ -526,7 +526,7 @@ public abstract class AbstractManifestServlet
   }
 
   @Nonnull
-  final String getModuleName( @Nonnull final HttpServletRequest request )
+  protected String getModuleName( @Nonnull final HttpServletRequest request )
     throws ServletException
   {
     final String servletPath = request.getServletPath();


### PR DESCRIPTION
We currently use rebar-appcache for serving manifests, along with a scheme that
encodes the user's chosen locale in the url of the manifest. For example,
/MyApp/en.appcache or /MyApp/ar.appcache

Encoding the url in the appcache is preferable to using cookies because it allows 
users to have multiple languages cached offline, and to have different languages 
open in different tabs, which is often needed during trainings.
